### PR TITLE
Fix chat initialization gating and response parsing

### DIFF
--- a/lib/app_state.dart
+++ b/lib/app_state.dart
@@ -36,6 +36,7 @@ class FFAppState extends ChangeNotifier {
   set hfToken(String value) {
     _hfToken = value;
     secureStorage.setString('ff_hfToken', value);
+    notifyListeners();
   }
 
   void deleteHfToken() {
@@ -46,42 +47,49 @@ class FFAppState extends ChangeNotifier {
   String get downloadProgress => _downloadProgress;
   set downloadProgress(String value) {
     _downloadProgress = value;
+    notifyListeners();
   }
 
   double _downloadPercentage = 100.0;
   double get downloadPercentage => _downloadPercentage;
   set downloadPercentage(double value) {
     _downloadPercentage = value;
+    notifyListeners();
   }
 
   String _fileName = '';
   String get fileName => _fileName;
   set fileName(String value) {
     _fileName = value;
+    notifyListeners();
   }
 
   bool _isDownloading = false;
   bool get isDownloading => _isDownloading;
   set isDownloading(bool value) {
     _isDownloading = value;
+    notifyListeners();
   }
 
   bool _isInitializing = false;
   bool get isInitializing => _isInitializing;
   set isInitializing(bool value) {
     _isInitializing = value;
+    notifyListeners();
   }
 
   bool _modelSupportsVision = false;
   bool get modelSupportsVision => _modelSupportsVision;
   set modelSupportsVision(bool value) {
     _modelSupportsVision = value;
+    notifyListeners();
   }
 
   bool _isModelInitialized = false;
   bool get isModelInitialized => _isModelInitialized;
   set isModelInitialized(bool value) {
     _isModelInitialized = value;
+    notifyListeners();
   }
 }
 

--- a/lib/custom_code/flutter_gemma_library.dart
+++ b/lib/custom_code/flutter_gemma_library.dart
@@ -503,20 +503,23 @@ class FlutterGemmaLibrary {
 
         // Extract text from response - try different response types
         if (response is TextResponse) {
-          // TextResponse might have different property names - try common ones
+          // For TextResponse, the actual text is in the token field
           try {
-            return response.toString();
+            return response.token;
           } catch (e) {
             print(
                 'FlutterGemmaLibrary: Error extracting text from TextResponse: $e');
             return 'Error extracting response text.';
           }
-        } else if (response.toString().isNotEmpty) {
-          return response.toString();
         } else {
-          print(
-              'FlutterGemmaLibrary: Received non-text response: ${response.runtimeType}');
-          return 'Received unexpected response type.';
+          final text = response.toString();
+          if (text.isNotEmpty) {
+            return text;
+          } else {
+            print(
+                'FlutterGemmaLibrary: Received non-text response: ${response.runtimeType}');
+            return 'Received unexpected response type.';
+          }
         }
       } catch (e) {
         print('FlutterGemmaLibrary: Error sending message via chat: $e');


### PR DESCRIPTION
## Summary
- Ensure app state changes notify listeners so UI updates immediately
- Show image picker only when current model supports vision
- Disable chat input until model initialization completes
- Parse TextResponse tokens to remove extra wrappers from replies

## Testing
- `flutter test` *(fails: Failed assertion: line 1617 pos 12: '!timersPending')*


------
https://chatgpt.com/codex/tasks/task_e_68c36e864c9883259194fad0ee315541